### PR TITLE
remove shell if and use brew --prefix for PATH

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -21,11 +21,8 @@ export PATH="$HOME/.node/bin:$PATH"
 
 source $ZSH/oh-my-zsh.sh
 
-# apple intel homebrew path
-# export PATH="/usr/local/bin:$PATH"
-
-# apple silicon homebrew path
-# export PATH="/opt/homebrew/bin:$PATH"
+# Homebrew path
+export PATH="$(brew --prefix)/bin:$PATH"
 
 . /usr/local/opt/asdf/libexec/asdf.sh
 

--- a/zsh/main.sh
+++ b/zsh/main.sh
@@ -17,18 +17,6 @@ DEST_FILE=~/$(echo $FILE_NAME)
 log "Copying $FILE_NAME file"
 cp "./zsh/$(echo $FILE_NAME)" $DEST_FILE
 
-if [[ $(arch) == 'arm64' ]]; then
-  log "Adding Apple Silicon brew path to rc file"
-
-  echo \\n\# Apple silicon homebrew path >> $DEST_FILE
-  echo export PATH=\"/opt/homebrew/bin:\$PATH\" >> $DEST_FILE
-else
-  log "Adding Apple intel brew path to rc file"
-
-  echo \\n\# Apple intel homebrew path >> $DEST_FILE
-  echo export PATH=\"/usr/local/bin:\$PATH\" >> $DEST_FILE
-fi
-
 log "Setting custom Zsh theme"
 cp -rf "./zsh/jsegal_theme.zsh-theme" "$ZSH/custom/themes/jsegal_theme.zsh-theme"
 


### PR DESCRIPTION
Brew gives a convenient helper to get where it's installed to. No need to switch on chipset, although that was cool to learn.

https://docs.brew.sh/Manpage#--prefix---unbrewed---installed-formula-