### PR TITLE
rm tailwind css setting

### DIFF
--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -51,9 +51,6 @@
   },
 
   // tailwind stuffs
-  "[html]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
-  },
   "tailwindCSS.includeLanguages": {
     "elixir": "html",
     "phoenix-heex": "html"


### PR DESCRIPTION
conflicts with elixir-ls formatter for html.heex files. 