### PR TITLE
conditionally reference asdf bash script based on version

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -27,7 +27,18 @@ export PATH="$(brew --prefix)/bin:$PATH"
 
 # asdf configs
 export PATH=~/.asdf/shims:$PATH
-. $(brew --prefix asdf)/libexec/asdf.sh
+
+# asdf was rewritten from bash to go in 0.16 therefore there isn't a bash script
+# to reference anymore:
+# https://github.com/asdf-vm/asdf/releases/tag/v0.16.0
+#
+# this `if` block can be removed sometime in the future.
+if command -v asdf >/dev/null; then
+  ASDF_VERSION=$(asdf --version | sed 's/^v//')
+  if [ "$(printf '0.16.0\n%s\n' "$ASDF_VERSION" | sort -V | head -n1)" != "0.16.0" ]; then
+    . $(brew --prefix asdf)/libexec/asdf.sh
+  fi
+fi
 
 # Zsh configs
 PROMPT_EOL_MARK=''


### PR DESCRIPTION
I was getting something like the following after running a brew upgrade and brew update
`no such file or directory: /usr/local/opt/asdf/libexec/asdf.sh`

asdf was rewritten in go therefore no more sh script to reference.

https://github.com/asdf-vm/asdf/releases/tag/v0.16.0