### PR TITLE
Dotfiles bug fixes and optimizations

### DIFF
--- a/apple/main.sh
+++ b/apple/main.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -eo pipefail
 
 # get some helper functions up in here
 source ./utils/main.sh

--- a/apple/main.sh
+++ b/apple/main.sh
@@ -18,8 +18,6 @@ else
   xcode-select --install
 fi
 
-log "Setting up OSX defaults"
-
 # create dir and set default location for screenshots
 mkdir -p ~/Desktop/screenshots
 defaults write com.apple.screencapture location ~/Desktop/screenshots
@@ -56,9 +54,9 @@ defaults write NSGlobalDomain NSNavPanelExpandedStateForSaveMode2 -bool true
 defaults write com.apple.dock mineffect -string scale
 
 # kill things to take immediate effect
-killall SystemUIServer
-killall Finder
-killall Dock
+killall SystemUIServer || true
+killall Finder || true
+killall Dock || true
 
 log "Remove default programs that are bundled with OSX"
 sudo rm -rf /Applications/iMovie.app

--- a/asdf/main.sh
+++ b/asdf/main.sh
@@ -15,12 +15,14 @@ ASDF_PLUGINS=(
   "elixir https://github.com/asdf-vm/asdf-elixir.git"
   "erlang https://github.com/asdf-vm/asdf-erlang.git"
   "nodejs https://github.com/asdf-vm/asdf-nodejs.git"
-  "python"
+  "python https://github.com/asdf-community/asdf-python.git"
 )
 
 log "Installing asdf plugins"
 for asdf_plugin in "${ASDF_PLUGINS[@]}"; do
-  asdf plugin-add "$asdf_plugin"
+  plugin_name=$(echo "$asdf_plugin" | awk '{print $1}')
+  # shellcheck disable=SC2086
+  asdf plugin list | grep -q "^$plugin_name$" || asdf plugin-add $asdf_plugin
 done
 
 KERL_CONFIGURE_OPTIONS="--without-javac --with-ssl=$(brew --prefix openssl)"

--- a/asdf/main.sh
+++ b/asdf/main.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -eo pipefail
 
 # get some helper functions up in here
 source ./utils/main.sh

--- a/brew/main.sh
+++ b/brew/main.sh
@@ -39,6 +39,7 @@ PACKAGES=(
   coreutils
   colima
   fop
+  gh
   git
   gpg
   libxslt

--- a/brew/main.sh
+++ b/brew/main.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -eo pipefail
 
 # get some helper functions up in here
 source ./utils/main.sh

--- a/brew/main.sh
+++ b/brew/main.sh
@@ -16,7 +16,7 @@ if test ! "$(which brew)"; then
   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
   log "# Set  PATH, MANPATH, etc., for Homebrew."
-  echo "eval '$(/opt/homebrew/bin/brew shellenv)'" >> /Users/jimsegal/.zprofile
+  echo "eval '$(/opt/homebrew/bin/brew shellenv)'" >> "$HOME/.zprofile"
   eval "$(/opt/homebrew/bin/brew shellenv)"
 else
   log "Homebrew already installed, updating"
@@ -30,7 +30,7 @@ brew install zsh
 
 if test ! "$(which omz)"; then
   log "Installing Oh My Zsh"
-  sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+  RUNZSH=no sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
 fi
 
 PACKAGES=(
@@ -43,8 +43,6 @@ PACKAGES=(
   gpg
   libxslt
   mas
-  node
-  npm
   openssl
   pnpm
   postgresql@14

--- a/brew/main.sh
+++ b/brew/main.sh
@@ -59,7 +59,7 @@ log "Starting brew services"
 brew services start "${SERVICES[@]}"
 
 CASKS=(
-  firefox
+  brave-browser
   obsidian
   postico
   postman

--- a/docs/postgres-14-to-16-upgrade.md
+++ b/docs/postgres-14-to-16-upgrade.md
@@ -1,0 +1,127 @@
+# PostgreSQL 14 → 16 Upgrade Guide (macOS / Homebrew)
+
+## Before you start
+
+```bash
+# Confirm current version and data directory
+psql --version
+brew services list | grep postgres
+ls /usr/local/var/postgresql@14
+```
+
+Back up your databases:
+
+```bash
+pg_dumpall -U postgres > ~/postgres14_backup_$(date +%F).sql
+```
+
+---
+
+## 1. Install PostgreSQL 16
+
+```bash
+brew install postgresql@16
+```
+
+---
+
+## 2. Initialize a PostgreSQL 16 data directory
+
+```bash
+/usr/local/opt/postgresql@16/bin/initdb \
+  --locale=C -E UTF-8 \
+  /usr/local/var/postgresql@16
+```
+
+---
+
+## 3. Stop the running PostgreSQL 14 service
+
+```bash
+brew services stop postgresql@14
+```
+
+---
+
+## 4. Run pg_upgrade
+
+`pg_upgrade` migrates the data directory in-place without a dump/restore.
+
+```bash
+/usr/local/opt/postgresql@16/bin/pg_upgrade \
+  --old-datadir /usr/local/var/postgresql@14 \
+  --new-datadir /usr/local/var/postgresql@16 \
+  --old-bindir  /usr/local/opt/postgresql@14/bin \
+  --new-bindir  /usr/local/opt/postgresql@16/bin \
+  --check
+```
+
+The `--check` flag does a dry run — no data is moved. If it reports "Clusters are compatible", remove `--check` and run it for real:
+
+```bash
+/usr/local/opt/postgresql@16/bin/pg_upgrade \
+  --old-datadir /usr/local/var/postgresql@14 \
+  --new-datadir /usr/local/var/postgresql@16 \
+  --old-bindir  /usr/local/opt/postgresql@14/bin \
+  --new-bindir  /usr/local/opt/postgresql@16/bin
+```
+
+---
+
+## 5. Start PostgreSQL 16
+
+```bash
+brew services start postgresql@16
+```
+
+---
+
+## 6. Verify
+
+```bash
+psql --version                        # should report 16.x
+psql -U postgres -c "SELECT version();"
+\l                                    # list databases — all should be present
+```
+
+If anything looks wrong, your PostgreSQL 14 data directory is untouched and you can restart the old service:
+
+```bash
+brew services stop postgresql@16
+brew services start postgresql@14
+```
+
+---
+
+## 7. Update statistics and clean up
+
+After confirming everything works, run the post-upgrade steps pg_upgrade generates:
+
+```bash
+# Update optimizer statistics (pg_upgrade prints this command after a successful run)
+/usr/local/opt/postgresql@16/bin/vacuumdb --all --analyze-in-stages
+
+# Remove the old cluster (pg_upgrade also generates a delete_old_cluster.sh script)
+./delete_old_cluster.sh
+```
+
+Then uninstall PostgreSQL 14:
+
+```bash
+brew services stop postgresql@14   # no-op if already stopped
+brew uninstall postgresql@14
+```
+
+---
+
+## 8. Update dotfiles
+
+In `brew/main.sh`, change the package and service references from `postgresql@14` to `postgresql@16`:
+
+```bash
+# brew/main.sh — PACKAGES array
+postgresql@16
+
+# brew/main.sh — SERVICES array
+postgresql@16
+```

--- a/fresh-setup.sh
+++ b/fresh-setup.sh
@@ -6,7 +6,7 @@ set -e
 source ./utils/main.sh
 
 # log "Updating permission to execute files in $(pwd)"
-chmod -R 755 ..
+chmod -R 755 .
 
 # Order of these scripts is important
 

--- a/fresh-setup.sh
+++ b/fresh-setup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -eo pipefail
 
 # get some helper functions up in here
 source ./utils/main.sh

--- a/git/main.sh
+++ b/git/main.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -eo pipefail
 
 # get some helper functions up in here
 source ./utils/main.sh

--- a/utils/main.sh
+++ b/utils/main.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -eo pipefail
 
 log () {
   echo

--- a/vim/main.sh
+++ b/vim/main.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -eo pipefail
 
 # get some helper functions up in here
 source ./utils/main.sh

--- a/vscode/main.sh
+++ b/vscode/main.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -eo pipefail
 
 # get some helper functions up in here
 source ./utils/main.sh

--- a/zsh/main.sh
+++ b/zsh/main.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -eo pipefail
 
 # get some helper functions up in here
 source ./utils/main.sh

--- a/zsh/main.sh
+++ b/zsh/main.sh
@@ -34,11 +34,8 @@ log "Setting custom Zsh theme"
 cp -rf "./zsh/jsegal_theme.zsh-theme" "$ZSH/custom/themes/jsegal_theme.zsh-theme"
 
 log "Installing Powerline Fonts"
-# clone
-git clone https://github.com/powerline/fonts.git --depth=1
-# install
-cd fonts
-./install.sh
-# clean-up a bit
-cd ..
-rm -rf fonts
+if [ ! -d "$HOME/.local/share/fonts" ] || ! fc-list | grep -q "Powerline"; then
+  git clone https://github.com/powerline/fonts.git --depth=1
+  (cd fonts && ./install.sh)
+  rm -rf fonts
+fi


### PR DESCRIPTION
## Summary

- Fix `chmod -R 755 ..` → `.` in `fresh-setup.sh` (was chmoding the parent directory)
- Fix `killall` calls in `apple/main.sh` with `|| true` so they don't abort under `set -e`; remove duplicate log line
- Fix hardcoded `/Users/jimsegal/.zprofile` → `$HOME/.zprofile` in `brew/main.sh`
- Add `RUNZSH=no` to Oh My Zsh installer so it doesn't replace the shell and halt the script
- Remove `node`/`npm` from brew packages — asdf manages nodejs, brew versions shadow asdf shims
- Fix word-splitting bug in `asdf/main.sh` plugin-add loop; make plugin installs idempotent; add explicit URL for python plugin
- Make Powerline font install idempotent in `zsh/main.sh`; use subshell for `cd fonts`
- Add `set -o pipefail` to all scripts
- Swap `firefox` for `brave-browser` in brew casks
- Add `gh` CLI to brew packages
- Add PostgreSQL 14 → 16 upgrade guide (`docs/postgres-14-to-16-upgrade.md`)

## Test plan

- [ ] `shellcheck` passes on all scripts (`shellcheck apple/main.sh asdf/main.sh brew/main.sh zsh/main.sh fresh-setup.sh utils/main.sh`)
- [ ] Second run of `fresh-setup.sh` exits cleanly with no re-install failures
- [ ] `which node` resolves to `~/.asdf/shims/node`, not `/usr/local/bin/node`

🤖 Generated with [Claude Code](https://claude.com/claude-code)